### PR TITLE
Remove inaccurate comment about adversarial loss in wgan-gp

### DIFF
--- a/models/wgan_gp.py
+++ b/models/wgan_gp.py
@@ -144,7 +144,6 @@ class WGANGP(LightningModule):
             valid = torch.ones(imgs.size(0), 1)
             valid = valid.type_as(imgs)
 
-            # adversarial loss is binary cross-entropy
             g_loss = -torch.mean(self.discriminator(self(z)))
             tqdm_dict = {'g_loss': g_loss}
             output = OrderedDict({


### PR DESCRIPTION
Hello,

thank you for your implementations. In WGAN-GP, there is an inaccurate comment about the loss used. It is not a binary cross-entropy loss, but rather the negated mean of the discriminator logits.